### PR TITLE
Lista la funcionalidad de actualizar perfil de usuario

### DIFF
--- a/front/src/app/update-user/page.tsx
+++ b/front/src/app/update-user/page.tsx
@@ -1,0 +1,9 @@
+import UpdateUserForm from "@/components/UpdateUserForm/UpdateUserForm";
+
+export default function UpdateUserPage() {
+    return (
+        <div>
+            <UpdateUserForm />
+        </div>
+    );
+}

--- a/front/src/components/AppointmentForm/AppointmentForm.tsx
+++ b/front/src/components/AppointmentForm/AppointmentForm.tsx
@@ -19,7 +19,12 @@ const AppointmentForm = () => {
             toast.error("Proveedor no encontrado.");
             router.push("/");
         }
-    }, [providerId, router]);
+
+        if (user && (!user.phone || !user.address)) {
+            toast.error("Faltan datos importantes en tu perfil. Por favor, actualiza tu información.");
+            router.push(`/update-user?id=${user.id}`);
+        }
+    }, [providerId, user, router]);
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();

--- a/front/src/components/DashboardContent/DashboardContent.tsx
+++ b/front/src/components/DashboardContent/DashboardContent.tsx
@@ -10,10 +10,10 @@ import ServiceButton from "./ServiceButton";
 import { useEffect } from "react";
 
 export default function DashboardContent() {
-    const { user, token } = useAuth(); // Usamos el contexto de autenticación
+    const { user, token } = useAuth();
     const { appointments, refreshAppointments } = useAppointments();
 
-    const isLoggedIn = !!user; // Verificamos si el usuario está autenticado
+    const isLoggedIn = !!user;
 
     useEffect(() => {
         if (user && token) {
@@ -33,7 +33,7 @@ export default function DashboardContent() {
         <section className="w-full min-h-screen bg-background px-6 py-10 md:px-[10%] dark:text-white">
             {isLoggedIn ? (
                 <div className="max-w-6xl mx-auto flex flex-col gap-8 items-center">
-                    {/* Imagen + nombre */}
+                    
                     <div className="flex flex-col items-center gap-4">
                         <UserImage
                             imgUrl={user?.imgUrl ?? undefined}
@@ -44,12 +44,12 @@ export default function DashboardContent() {
                         </h1>
                     </div>
 
-                    {/* Botón de servicios (solo si está logueado por backend) */}
+                    
                     {user && (
                         <ServiceButton params={params} />
                     )}
 
-                    {/* Info + Intereses */}
+                    
                     <div className="flex flex-wrap gap-6 w-full justify-center">
                         <div className="flex-1">
                             <UserInfo
@@ -66,7 +66,6 @@ export default function DashboardContent() {
                         )}
                     </div>
 
-                    {/* Turnos */}
                     <div className="w-full">
                         <UserAppointments appointments={appointments || []} />
                     </div>

--- a/front/src/components/DashboardContent/userAppointments.tsx
+++ b/front/src/components/DashboardContent/userAppointments.tsx
@@ -12,10 +12,8 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
 
     const isProvider = user?.serviceProfile?.status === "active";
 
-    /** estado principal que se renderiza */
     const [appointmentsState, setAppointmentsState] = useState<AppointmentType[]>([]);
 
-    /** ---------- helpers ---------- */
     const getStatusPriority = (s: AppointmentStatus) =>
         s === AppointmentStatus.CONFIRMED ? 1 :
             s === AppointmentStatus.COMPLETED ? 2 :
@@ -36,7 +34,6 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
                     s === AppointmentStatus.CANCELLED ? "Cancelado" :
                         s === AppointmentStatus.COMPLETED ? "Completado" : "Desconocido";
 
-    /** ---------- cargar / enriquecer turnos ---------- */
     useEffect(() => {
         const load = async () => {
             if (!isProvider) {
@@ -44,7 +41,6 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
                 return;
             }
 
-            // para proveedores traemos la versión completa
             const enriched = await Promise.all(
                 appointments.map(async (appt) => {
                     try {
@@ -61,7 +57,6 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
         load();
     }, [appointments, isProvider, getAppointmentById]);
 
-    /** ---------- cancelar turno ---------- */
     const handleCancel = (id: string) =>
         toast.warning("¿Seguro que quieres cancelar este turno?", {
             action: {
@@ -84,7 +79,6 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
             },
         });
 
-    /** ---------- render ---------- */
     return (
         <div className="w-full bg-quaternary/40 dark:bg-quinary/40 p-4 rounded-2xl border borders shadow-md">
             <h2 className="text-lg font-bold mb-3 border-b pb-1">

--- a/front/src/components/ServiceProviderUser/ServiceProviderUser.tsx
+++ b/front/src/components/ServiceProviderUser/ServiceProviderUser.tsx
@@ -96,7 +96,6 @@ const ServiceProviderUser: React.FC<ServiceProfileType> = ({
                   toast.error("Debes iniciar sesión para poder reservar un turno!");
                   return;
                 }
-                console.log("userId enviado al link:", id);
                 router.push(`/appointments?id=${id}`);
               }}
             />

--- a/front/src/components/UpdateUserForm/UpdateUserForm.tsx
+++ b/front/src/components/UpdateUserForm/UpdateUserForm.tsx
@@ -1,0 +1,71 @@
+"use client";
+import React, { useState } from "react";
+import { useAuth } from "@/contexts/authContext";
+import { useRouter } from "next/navigation";
+import { updateUser } from "@/services/userService";
+import { toast } from "sonner";
+
+const UpdateUserForm = () => {
+    const router = useRouter();
+    const { user, token, setUser } = useAuth();
+
+    const [phone, setPhone] = useState(user?.phone || "");
+    const [address, setAddress] = useState(user?.address || "");
+
+    const handleSubmit = async (e: React.FormEvent) => {
+        e.preventDefault();
+
+        if (!user || !user.id) {
+            toast.error("Usuario no autenticado.");
+            return;
+        }
+
+        try {
+            const response = await updateUser(user.id, Number(phone), address, token!);
+            if (response) {
+                setUser(response);
+                localStorage.setItem("user", JSON.stringify(response));
+                toast.success("Datos actualizados correctamente.");
+                router.push(`/appointments?id=${user.id}`);
+            }
+        } catch (err) {
+            toast.error("Hubo un error al actualizar los datos.");
+            console.error(err);
+        }
+    };
+
+    return (
+        <div className="max-w-2xl mx-auto mt-[15vh] p-4">
+            <h2 className="text-2xl font-semibold">Actualizar datos de usuario</h2>
+            <form onSubmit={handleSubmit} className="space-y-4">
+                <div>
+                    <label className="block text-sm font-medium">Teléfono</label>
+                    <input
+                        type="text"
+                        className="w-full dark:text-tertiary"
+                        value={phone}
+                        onChange={(e) => setPhone(e.target.value)}
+                        required
+                    />
+                </div>
+
+                <div>
+                    <label className="block text-sm font-medium">Dirección</label>
+                    <input
+                        type="text"
+                        className="w-full dark:text-tertiary"
+                        value={address}
+                        onChange={(e) => setAddress(e.target.value)}
+                        required
+                    />
+                </div>
+
+                <button type="submit" className="buttons px-4 py-2 rounded">
+                    Guardar cambios
+                </button>
+            </form>
+        </div>
+    );
+};
+
+export default UpdateUserForm;

--- a/front/src/services/userService.ts
+++ b/front/src/services/userService.ts
@@ -1,5 +1,6 @@
 import { UserType } from "@/helpers/typeMock";
 import { usersMock } from "@/helpers/dataMock";
+import { toast } from "sonner";
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL;
 const MODE = process.env.NEXT_PUBLIC_MODE;
@@ -27,7 +28,7 @@ export const getUserById = async (id: string): Promise<UserType | null> => {
         if (MODE === "developer") {
             return usersMock.find((user) => user.id === id) || null;
         } else if (MODE === "production") {
-            const response = await fetch(`${API_URL}/users/${id}`, { cache: "no-cache" });  {/* service-profile/{id} */}
+            const response = await fetch(`${API_URL}/users/${id}`, { cache: "no-cache" }); {/* service-profile/{id} */ }
             if (!response.ok) throw new Error("No se pudo obtener el usuario");
             return await response.json();
         }
@@ -58,29 +59,43 @@ export const getUserByEmail = async (email: string): Promise<UserType | null> =>
     return null;
 }
 
-export const updateUser = async (id: string, user: UserType): Promise<boolean> => {
-    // TODO: Implementar la lógica para actualizar el perfil del usuario por id
+export const updateUser = async (
+    id: string,
+    phone: number,
+    address: string,
+    token: string
+) => {
     try {
-        if (MODE === "developer") {
-            // ! Mock
-            return true;
-        } else if (MODE === "production") {
-            const response = await fetch(`${API_URL}/users/${id}`, {
-                method: "PUT",
-                headers: {
-                    "Content-Type": "application/json",
-                },
-                body: JSON.stringify(user),
-            });
-            return await response.json() || false;
-        }
-    } catch (error) {
-        console.error(error);
-        return false;
-    }
+        const updatedData = {
+            phone,
+            address,
+        };
 
-    return false;
-}
+        const response = await fetch(`${API_URL}/users/update/${id}`, {
+            method: 'PATCH',
+            headers: {
+                'Content-Type': 'application/json',
+                'Authorization': `Bearer ${token}`,
+            },
+            body: JSON.stringify(updatedData),
+        });
+
+        if (!response.ok) {
+            throw new Error('No se pudo actualizar la información del usuario');
+        }
+
+        const result = await response.json();
+
+        toast.success("Datos actualizados correctamente.");
+        return result;
+    } catch (err) {
+        toast.error("Hubo un error al actualizar los datos.");
+        console.error(err);
+    }
+};
+
+
+
 
 export const deleteUser = async (id: string): Promise<boolean> => {
     // TODO: Implementar la lógica para eliminar el perfil del usuario por id


### PR DESCRIPTION
Verifica a la hora de sacar un turno que tengas todos los datos necesarios. De no ser asi te redirige al formulario, y si lo completas correctamente te devuelve a la pagina de pedir turnos. Se refleja tanto en el dashboard como en el localStorage y la proxima vez al iniciar sesion con google, toma tus datos y con ellos te hace iniciar sesion directamente a traves de la base de datos para no pisar la data que actualizaste. Tambien corregimos el bucle infinito a la hora de pedir los turnos al back.