### PR TITLE
Correccion en appointments y dashboard

### DIFF
--- a/front/src/components/AppointmentForm/AppointmentForm.tsx
+++ b/front/src/components/AppointmentForm/AppointmentForm.tsx
@@ -20,7 +20,10 @@ const AppointmentForm = () => {
             router.push("/");
         }
 
-        if (user && (!user.phone || !user.address)) {
+        if (user && (
+            !user.phone || user.phone === "0" ||
+            !user.address || user.address === "Dirección no especificada"
+        )) {
             toast.error("Faltan datos importantes en tu perfil. Por favor, actualiza tu información.");
             router.push(`/update-user?id=${user.id}`);
         }
@@ -61,13 +64,11 @@ const AppointmentForm = () => {
             additionalNotes: notes,
         };
 
-        console.log("Token:", token);
-        console.log("Payload:", payload);
-
         try {
             const response = await newAppointment(payload, token!);
             if (response) {
                 toast.success("Turno creado con éxito. Te llegará un correo con los detalles.");
+                router.refresh()
                 router.push("/dashboard");
             } else {
                 toast.error("Hubo un error al crear el turno.");

--- a/front/src/components/DashboardContent/DashboardContent.tsx
+++ b/front/src/components/DashboardContent/DashboardContent.tsx
@@ -33,7 +33,7 @@ export default function DashboardContent() {
         <section className="w-full min-h-screen bg-background px-6 py-10 md:px-[10%] dark:text-white">
             {isLoggedIn ? (
                 <div className="max-w-6xl mx-auto flex flex-col gap-8 items-center">
-                    
+
                     <div className="flex flex-col items-center gap-4">
                         <UserImage
                             imgUrl={user?.imgUrl ?? undefined}
@@ -44,18 +44,18 @@ export default function DashboardContent() {
                         </h1>
                     </div>
 
-                    
+
                     {user && (
                         <ServiceButton params={params} />
                     )}
 
-                    
+
                     <div className="flex flex-wrap gap-6 w-full justify-center">
                         <div className="flex-1">
                             <UserInfo
                                 email={user?.email ?? ""}
-                                phone={user?.phone ?? "No especificado"}
-                                address={user?.address ?? "No especificado"}
+                                phone={user?.phone !== "0" ? user?.phone : "No especificado"}
+                                address={user?.address !== "Dirección no especificada" ? user?.address : "No especificado"}
                             />
                         </div>
 
@@ -67,7 +67,7 @@ export default function DashboardContent() {
                     </div>
 
                     <div className="w-full">
-                        <UserAppointments appointments={appointments || []} />
+                        <UserAppointments/>
                     </div>
                 </div>
             ) : (

--- a/front/src/components/DashboardContent/userAppointments.tsx
+++ b/front/src/components/DashboardContent/userAppointments.tsx
@@ -7,9 +7,9 @@ import { FaTimes, FaCheck, FaStar } from "react-icons/fa";
 import { createReview } from "@/services/reviewServices";
 import StarRating from "../StartRating/StartRating";
 
-export default function UserAppointments({ appointments }: { appointments: AppointmentType[] }) {
+export default function UserAppointments() {
     const { user, token } = useAuth();
-    const { cancelAppointment, getAppointmentById, completeAppointment } = useAppointments();
+    const { appointments, cancelAppointment, getAppointmentById, completeAppointment } = useAppointments();
     const [selectedAppointment, setSelectedAppointment] = useState<AppointmentType | null>(null);
     const [rating, setRating] = useState<number>(0);
     const [comment, setComment] = useState<string>("");
@@ -130,7 +130,6 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
         try {
             const updatedAppointment = await createReview(selectedAppointment?.id ?? "", { rating, comment }, token);
 
-            // Actualiza el estado para reflejar que la reseña ya ha sido enviada
             setAppointmentsState((prev) =>
                 orderArray(
                     prev.map((a) =>
@@ -154,7 +153,7 @@ export default function UserAppointments({ appointments }: { appointments: Appoi
             );
 
             toast.success("¡Reseña enviada correctamente!");
-            handleCloseReviewModal();  // Cierra el modal después de enviar la reseña
+            handleCloseReviewModal();
         } catch (error) {
             toast.error("Hubo un error al enviar la reseña.");
         }

--- a/front/src/components/UpdateUserForm/UpdateUserForm.tsx
+++ b/front/src/components/UpdateUserForm/UpdateUserForm.tsx
@@ -9,8 +9,8 @@ const UpdateUserForm = () => {
     const router = useRouter();
     const { user, token, setUser } = useAuth();
 
-    const [phone, setPhone] = useState(user?.phone || "");
-    const [address, setAddress] = useState(user?.address || "");
+    const [phone, setPhone] = useState("");
+    const [address, setAddress] = useState("");
 
     const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -26,7 +26,7 @@ const UpdateUserForm = () => {
                 setUser(response);
                 localStorage.setItem("user", JSON.stringify(response));
                 toast.success("Datos actualizados correctamente.");
-                router.push(`/appointments?id=${user.id}`);
+                router.back();
             }
         } catch (err) {
             toast.error("Hubo un error al actualizar los datos.");
@@ -37,12 +37,13 @@ const UpdateUserForm = () => {
     return (
         <div className="max-w-2xl mx-auto mt-[15vh] p-4">
             <h2 className="text-2xl font-semibold">Actualizar datos de usuario</h2>
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-4 border p-4 rounded-md shadow-md">
                 <div>
                     <label className="block text-sm font-medium">Teléfono</label>
                     <input
                         type="text"
-                        className="w-full dark:text-tertiary"
+                        className="w-full dark:text-tertiary border rounded-md"
+                        placeholder="Ej: 1234567890"
                         value={phone}
                         onChange={(e) => setPhone(e.target.value)}
                         required
@@ -53,7 +54,8 @@ const UpdateUserForm = () => {
                     <label className="block text-sm font-medium">Dirección</label>
                     <input
                         type="text"
-                        className="w-full dark:text-tertiary"
+                        className="w-full dark:text-tertiary border rounded-md"
+                        placeholder="Ej: Calle Falsa 123"
                         value={address}
                         onChange={(e) => setAddress(e.target.value)}
                         required

--- a/front/src/contexts/authContext.tsx
+++ b/front/src/contexts/authContext.tsx
@@ -59,6 +59,10 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
 
             const updatedUser = await res.json();
 
+            if (updatedUser.phone === 0) {
+                updatedUser.phone = undefined;
+            }
+
             localStorage.setItem("user", JSON.stringify(updatedUser));
             setUser(updatedUser);
         } catch {

--- a/front/src/services/appointmentService.ts
+++ b/front/src/services/appointmentService.ts
@@ -23,15 +23,24 @@ export const newAppointment = async (
         body: JSON.stringify(payload),
     });
 
-    const data = await response.json(); // ✅ solo una vez
+    const data = await response.json();
     console.log("Respuesta del servidor:", data);
 
     if (!response.ok) {
         throw new Error(data.message || "Error al crear el turno");
     }
 
-    return data;
+    return {
+        id: data.id,
+        user: data.user,  // o `users`, depende de tu backend
+        provider: data.provider,
+        date: new Date(data.date),
+        appointmentStatus: data.appointmentStatus,
+        additionalNotes: data.additionalNotes,
+        review: data.review,
+    };
 };
+
 
 
 export const getMyAppointments = async (): Promise<AppointmentType[]> => {

--- a/front/src/services/userService.ts
+++ b/front/src/services/userService.ts
@@ -66,10 +66,11 @@ export const updateUser = async (
     token: string
 ) => {
     try {
-        const updatedData = {
-            phone,
-            address,
-        };
+        const updatedData: { phone?: number; address: string } = { address };
+
+        if (phone && phone !== 0) {
+            updatedData.phone = phone;
+        }
 
         const response = await fetch(`${API_URL}/users/update/${id}`, {
             method: 'PATCH',
@@ -93,6 +94,7 @@ export const updateUser = async (
         console.error(err);
     }
 };
+
 
 
 


### PR DESCRIPTION
Ahora al loguear con google no devuelve un 0 y un string los campos phone y address, y de ser así, se manejan como informacion no especificada y habilitan correctamente el formulario de agregar campos para crear un turno. Los turnos se muestran en el dashboard al ser creados sin necesidad de refrescar la pagina.